### PR TITLE
feat: add Codex skill install support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ All notable changes to cheat-on-content will be documented here.
 
 v2 系统让"拍后改稿"成为一等公民：v1 留作档案，v2 基于实际拍摄稿重判，diff(v1, v2) 本身成为 rubric 升级的强证据（用户改稿改高了 ER → 工具学到这个用户的 ER 阈值跟当前公式不一致）。盲预测原则保留：v2 仍在发布前完成，没有播放数据可"作弊"。
 
+### Added — Codex 安装兼容（@songth1ef [#6](https://github.com/XBuilderLAB/cheat-on-content/pull/6)）
+
+- **`install.sh --codex`**：安装根路由 skill `cheat-on-content` 和 13 个子 skill 到 `~/.codex/skills/`
+- **`install.sh --all`**：同时安装 Claude Code 和 Codex skill
+- **`uninstall.sh --codex` / `--all`**：对称卸载 Codex 或双端安装
+- **Codex 路由说明**：Codex 用自然语言触发同一套流程，不依赖 Claude Code 的 `/cheat-*` slash-command harness
+
 ### Added — Migration 系统（让长期迭代不打断老用户）
 
 - **`/cheat-migrate` skill**：把老用户 `.cheat-state.json` 从旧 `schema_version` 升级到当前 `LATEST_SCHEMA`。幂等、不跳版、失败停在断点

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@
 
 ## 📦 安装
 
+### Claude Code
+
 ```bash
 git clone https://github.com/XBuilderLAB/cheat-on-content.git
 cd cheat-on-content
@@ -75,13 +77,27 @@ bash install.sh
 
 13 个子 skill 软链接到 `~/.claude/skills/`。装一次，所有内容项目都能用。
 
-> 冻结版本：`bash install.sh --copy` / 卸载：`bash uninstall.sh`（不动你的内容数据）
+### Codex
+
+```bash
+git clone https://github.com/XBuilderLAB/cheat-on-content.git
+cd cheat-on-content
+bash install.sh --codex
+```
+
+Codex 会安装根路由 skill `cheat-on-content` + 13 个子 skill 到 `~/.codex/skills/`。如果当前 Codex 会话看不到新 skill，重开一次会话。
+
+> 同时安装 Claude Code + Codex：`bash install.sh --all`
+>
+> 冻结版本：`bash install.sh --copy` / `bash install.sh --codex --copy`
+>
+> 卸载：`bash uninstall.sh` / `bash uninstall.sh --codex`（不动你的内容数据）
 
 ---
 
 ## 🚀 第一次跑
 
-在你的内容项目目录里开 Claude Code，说：
+在你的内容项目目录里开 Claude Code 或 Codex，说：
 
 ```
 初始化 cheat-on-content
@@ -102,7 +118,7 @@ bash install.sh
 状态 / 抓热点 / 找选题 / 升级 rubric / 找对标
 ```
 
-每次开会话 hook 自动报告 buffer + 待复盘 + top 候选——你不用主动问。
+Claude Code 每次开会话 hook 自动报告 buffer + 待复盘 + top 候选——你不用主动问。Codex 当前没有等价 hook 自动注入，直接说 `状态` 可获得同样看板。
 
 完整工作流 + 子 skill 细节见 [SKILL.md](SKILL.md)。
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -21,6 +21,17 @@ allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Skill, mcp__llm-chat__cha
 
 本文件是**总协议 + 路由器**。具体每个阶段的工作流在 `skills/cheat-*/SKILL.md` 各子 skill 里。
 
+## Codex compatibility
+
+Codex 没有 Claude Code 的 slash-command harness。安装到 Codex 后，按自然语言触发同一套路由即可：
+
+- `初始化 cheat-on-content` → 读取并执行 `skills/cheat-init/SKILL.md`
+- `打分这篇 scripts/foo.md` → 读取并执行 `skills/cheat-score/SKILL.md`
+- `启动预测 scripts/foo.md` → 读取并执行 `skills/cheat-predict/SKILL.md`
+- `拍了 ...` / `已发布 ...` / `复盘 ...` / `升级 rubric` / `状态` → 分别读取对应 `skills/cheat-*/SKILL.md`
+
+执行时遵循本文件的三条原则和路由表；不要依赖 `/cheat-*` 命令是否存在。Claude Code 专用 hook（`.claude/settings.json`）仍只在 Claude Code 里自动触发；Codex 中需要用户主动说 `状态` 查看 buffer、待复盘和候选池。
+
 ---
 
 ## 三条不可妥协原则

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 #
 # cheat-on-content / install.sh
 #
-# Symlinks the 13 sub-skills into ~/.claude/skills/ so Claude Code can find them
-# globally. Re-runnable safely (sf flags overwrite existing links).
+# Symlinks the skills into Claude Code and/or Codex skill directories so agents
+# can find them globally. Re-runnable safely (overwrite after confirmation).
 #
 # After install, in any content project directory: open Claude Code → say "初始化"
 # → /cheat-init runs the onboarding.
@@ -11,8 +11,11 @@
 # To uninstall: bash uninstall.sh
 #
 # Usage:
-#   bash install.sh                    # symlink (default; dev-friendly, changes reflect immediately)
-#   bash install.sh --copy             # copy instead of symlink (frozen version, dev changes ignored)
+#   bash install.sh                    # Claude Code install, symlink mode (default)
+#   bash install.sh --copy             # Claude Code install, copy mode
+#   bash install.sh --codex            # Codex install into ~/.codex/skills/
+#   bash install.sh --all              # install for Claude Code and Codex
+#   bash install.sh --codex --copy     # Codex install, copy mode
 #   bash install.sh --reinstall-hooks <project-dir>
 #                                      # rewrite hook scripts in an existing user project's .cheat-hooks/
 #                                      # (use after git pull when CHANGELOG mentions hook script changes;
@@ -20,7 +23,7 @@
 
 set -euo pipefail
 
-SKILLS=(
+SUB_SKILLS=(
   cheat-init
   cheat-learn-from
   cheat-seed
@@ -36,10 +39,14 @@ SKILLS=(
   cheat-migrate
 )
 
+CLAUDE_SKILLS=("${SUB_SKILLS[@]}")
+CODEX_SKILLS=(cheat-on-content "${SUB_SKILLS[@]}")
+
 # Resolve the directory containing THIS script (the source root) — needed early for both modes
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 MODE="symlink"
+TARGET_AGENT="claude"
 
 # --- --reinstall-hooks branch: rewrite a user project's hook scripts only ---
 if [[ "${1:-}" == "--reinstall-hooks" ]]; then
@@ -91,12 +98,40 @@ if [[ "${1:-}" == "--reinstall-hooks" ]]; then
   exit 0
 fi
 
-if [[ "${1:-}" == "--copy" ]]; then
-  MODE="copy"
-fi
+for arg in "$@"; do
+  case "$arg" in
+    --copy)
+      MODE="copy"
+      ;;
+    --claude)
+      TARGET_AGENT="claude"
+      ;;
+    --codex)
+      TARGET_AGENT="codex"
+      ;;
+    --all)
+      TARGET_AGENT="all"
+      ;;
+    --help|-h)
+      sed -n '1,35p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "❌ Unknown argument: $arg"
+      echo "   Usage: bash install.sh [--copy] [--claude|--codex|--all]"
+      exit 1
+      ;;
+  esac
+done
 
 # Sanity check: confirm we're in the cheat-on-content root
-for s in "${SKILLS[@]}"; do
+if [[ ! -f "$SCRIPT_DIR/SKILL.md" ]]; then
+  echo "❌ Missing: $SCRIPT_DIR/SKILL.md"
+  echo "   Are you running install.sh from the cheat-on-content root?"
+  exit 1
+fi
+
+for s in "${SUB_SKILLS[@]}"; do
   if [[ ! -f "$SCRIPT_DIR/skills/$s/SKILL.md" ]]; then
     echo "❌ Missing: $SCRIPT_DIR/skills/$s/SKILL.md"
     echo "   Are you running install.sh from the cheat-on-content root?"
@@ -104,32 +139,84 @@ for s in "${SKILLS[@]}"; do
   fi
 done
 
-# Ensure ~/.claude/skills exists
-mkdir -p "$HOME/.claude/skills"
-
-echo ""
-echo "Installing cheat-on-content (mode: $MODE)"
-echo "  source: $SCRIPT_DIR"
-echo "  target: $HOME/.claude/skills/"
-echo ""
-
-# Detect any existing installation that conflicts
-WARNED=0
-for s in "${SKILLS[@]}"; do
-  TARGET="$HOME/.claude/skills/$s"
-  if [[ -e "$TARGET" || -L "$TARGET" ]]; then
-    if [[ -L "$TARGET" ]]; then
-      EXISTING=$(readlink "$TARGET")
-      if [[ "$EXISTING" != "$SCRIPT_DIR/skills/$s" ]]; then
-        echo "⚠️  $TARGET already symlinked to: $EXISTING"
-        WARNED=1
-      fi
-    else
-      echo "⚠️  $TARGET exists (not a symlink) — will be overwritten"
-      WARNED=1
-    fi
+skill_source() {
+  local skill="$1"
+  if [[ "$skill" == "cheat-on-content" ]]; then
+    echo "$SCRIPT_DIR"
+  else
+    echo "$SCRIPT_DIR/skills/$skill"
   fi
-done
+}
+
+detect_conflicts() {
+  local target_dir="$1"
+  shift
+  local warned=0
+
+  for s in "$@"; do
+    local src
+    src=$(skill_source "$s")
+    local target="$target_dir/$s"
+    if [[ -e "$target" || -L "$target" ]]; then
+      if [[ -L "$target" ]]; then
+        local existing
+        existing=$(readlink "$target")
+        if [[ "$existing" != "$src" ]]; then
+          echo "⚠️  $target already symlinked to: $existing"
+          warned=1
+        fi
+      else
+        echo "⚠️  $target exists (not a symlink) — will be overwritten"
+        warned=1
+      fi
+    fi
+  done
+
+  return "$warned"
+}
+
+install_skills() {
+  local label="$1"
+  local target_dir="$2"
+  shift 2
+
+  mkdir -p "$target_dir"
+
+  echo ""
+  echo "Installing cheat-on-content for $label (mode: $MODE)"
+  echo "  source: $SCRIPT_DIR"
+  echo "  target: $target_dir/"
+  echo ""
+
+  for s in "$@"; do
+    local src
+    src=$(skill_source "$s")
+    local dst="$target_dir/$s"
+
+    if [[ -e "$dst" || -L "$dst" ]]; then
+      rm -rf "$dst"
+    fi
+
+    if [[ "$MODE" == "symlink" ]]; then
+      ln -s "$src" "$dst"
+      echo "  ✓ symlinked: $s"
+    else
+      cp -R "$src" "$dst"
+      if [[ "$s" == "cheat-on-content" ]]; then
+        rm -rf "$dst/.git"
+      fi
+      echo "  ✓ copied:    $s"
+    fi
+  done
+}
+
+WARNED=0
+if [[ "$TARGET_AGENT" == "claude" || "$TARGET_AGENT" == "all" ]]; then
+  detect_conflicts "$HOME/.claude/skills" "${CLAUDE_SKILLS[@]}" || WARNED=1
+fi
+if [[ "$TARGET_AGENT" == "codex" || "$TARGET_AGENT" == "all" ]]; then
+  detect_conflicts "$HOME/.codex/skills" "${CODEX_SKILLS[@]}" || WARNED=1
+fi
 
 if [[ $WARNED -eq 1 ]]; then
   echo ""
@@ -141,24 +228,13 @@ if [[ $WARNED -eq 1 ]]; then
   fi
 fi
 
-# Install each sub-skill
-for s in "${SKILLS[@]}"; do
-  SRC="$SCRIPT_DIR/skills/$s"
-  DST="$HOME/.claude/skills/$s"
+if [[ "$TARGET_AGENT" == "claude" || "$TARGET_AGENT" == "all" ]]; then
+  install_skills "Claude Code" "$HOME/.claude/skills" "${CLAUDE_SKILLS[@]}"
+fi
 
-  # Remove any existing entry first (to allow overwriting non-symlink dirs)
-  if [[ -e "$DST" || -L "$DST" ]]; then
-    rm -rf "$DST"
-  fi
-
-  if [[ "$MODE" == "symlink" ]]; then
-    ln -s "$SRC" "$DST"
-    echo "  ✓ symlinked: $s"
-  else
-    cp -R "$SRC" "$DST"
-    echo "  ✓ copied:    $s"
-  fi
-done
+if [[ "$TARGET_AGENT" == "codex" || "$TARGET_AGENT" == "all" ]]; then
+  install_skills "Codex" "$HOME/.codex/skills" "${CODEX_SKILLS[@]}"
+fi
 
 echo ""
 echo "✅ Install complete!"
@@ -167,17 +243,29 @@ echo "Next steps:"
 echo "  1. cd into your content project (or create one):"
 echo "       mkdir ~/my-channel && cd ~/my-channel"
 echo ""
-echo "  2. Open Claude Code in that directory"
+echo "  2. Open Claude Code or Codex in that directory"
 echo ""
 echo "  3. In the chat, say:"
 echo "       初始化"
 echo "       (or: 初始化 cheat-on-content)"
 echo ""
-echo "Verify install: ls -la ~/.claude/skills/ | grep cheat"
+if [[ "$TARGET_AGENT" == "claude" || "$TARGET_AGENT" == "all" ]]; then
+  echo "Verify Claude install: ls -la ~/.claude/skills/ | grep cheat"
+fi
+if [[ "$TARGET_AGENT" == "codex" || "$TARGET_AGENT" == "all" ]]; then
+  echo "Verify Codex install:  ls -la ~/.codex/skills/ | grep cheat"
+  echo "Note: restart Codex if the new skills do not appear in the current session."
+fi
 echo ""
 if [[ "$MODE" == "symlink" ]]; then
   echo "ℹ️  Mode: symlink — edits to source SKILL.md files take effect immediately."
-  echo "   To switch to frozen copy: bash install.sh --copy"
+  if [[ "$TARGET_AGENT" == "codex" ]]; then
+    echo "   To switch to frozen copy: bash install.sh --codex --copy"
+  elif [[ "$TARGET_AGENT" == "all" ]]; then
+    echo "   To switch to frozen copy: bash install.sh --all --copy"
+  else
+    echo "   To switch to frozen copy: bash install.sh --copy"
+  fi
 else
   echo "ℹ️  Mode: copy — frozen at install time. Re-run install.sh to update."
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,17 +2,22 @@
 #
 # cheat-on-content / uninstall.sh
 #
-# Removes the 13 sub-skills from ~/.claude/skills/.
+# Removes cheat-on-content skills from Claude Code and/or Codex skill dirs.
 #
 # Does NOT touch any content project's data (.cheat-state.json, predictions/,
 # rubric_notes.md, candidates.md, etc.) — those live in your content directories
 # and uninstalling the skill leaves your work intact.
 #
+# Usage:
+#   bash uninstall.sh          # remove Claude Code install (default)
+#   bash uninstall.sh --codex  # remove Codex install
+#   bash uninstall.sh --all    # remove both
+#
 # To re-install: bash install.sh
 
 set -euo pipefail
 
-SKILLS=(
+SUB_SKILLS=(
   cheat-init
   cheat-learn-from
   cheat-seed
@@ -28,25 +33,68 @@ SKILLS=(
   cheat-migrate
 )
 
-echo ""
-echo "Removing cheat-on-content from ~/.claude/skills/"
-echo ""
+CLAUDE_SKILLS=("${SUB_SKILLS[@]}")
+CODEX_SKILLS=(cheat-on-content "${SUB_SKILLS[@]}")
+
+TARGET_AGENT="claude"
+for arg in "$@"; do
+  case "$arg" in
+    --claude)
+      TARGET_AGENT="claude"
+      ;;
+    --codex)
+      TARGET_AGENT="codex"
+      ;;
+    --all)
+      TARGET_AGENT="all"
+      ;;
+    --help|-h)
+      sed -n '1,25p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "❌ Unknown argument: $arg"
+      echo "   Usage: bash uninstall.sh [--claude|--codex|--all]"
+      exit 1
+      ;;
+  esac
+done
 
 REMOVED=0
-for s in "${SKILLS[@]}"; do
-  TARGET="$HOME/.claude/skills/$s"
-  if [[ -L "$TARGET" ]]; then
-    rm "$TARGET"
-    echo "  ✓ removed symlink:   $s"
-    REMOVED=$((REMOVED + 1))
-  elif [[ -d "$TARGET" ]]; then
-    rm -rf "$TARGET"
-    echo "  ✓ removed directory: $s"
-    REMOVED=$((REMOVED + 1))
-  else
-    echo "  · not found:         $s (skipped)"
-  fi
-done
+
+remove_skills() {
+  local label="$1"
+  local target_dir="$2"
+  shift 2
+
+  echo ""
+  echo "Removing cheat-on-content from $label:"
+  echo "  target: $target_dir/"
+  echo ""
+
+  for s in "$@"; do
+    local target="$target_dir/$s"
+    if [[ -L "$target" ]]; then
+      rm "$target"
+      echo "  ✓ removed symlink:   $s"
+      REMOVED=$((REMOVED + 1))
+    elif [[ -d "$target" ]]; then
+      rm -rf "$target"
+      echo "  ✓ removed directory: $s"
+      REMOVED=$((REMOVED + 1))
+    else
+      echo "  · not found:         $s (skipped)"
+    fi
+  done
+}
+
+if [[ "$TARGET_AGENT" == "claude" || "$TARGET_AGENT" == "all" ]]; then
+  remove_skills "Claude Code" "$HOME/.claude/skills" "${CLAUDE_SKILLS[@]}"
+fi
+
+if [[ "$TARGET_AGENT" == "codex" || "$TARGET_AGENT" == "all" ]]; then
+  remove_skills "Codex" "$HOME/.codex/skills" "${CODEX_SKILLS[@]}"
+fi
 
 echo ""
 if [[ $REMOVED -gt 0 ]]; then
@@ -59,5 +107,5 @@ echo "Note: your content projects' data (predictions/, rubric_notes.md, .cheat-s
 echo "      .cheat-hooks/, candidates.md, etc.) are NOT touched. They live in each content"
 echo "      project directory. To clean a specific content project, delete those files manually."
 echo ""
-echo "To re-install: bash install.sh (from cheat-on-content source root)"
+echo "To re-install: bash install.sh [--codex|--all] (from cheat-on-content source root)"
 echo ""


### PR DESCRIPTION
## What
                                                                                    
  `install.sh` / `uninstall.sh` 增加 `--codex` / `--all` 模式，把 root `SKILL.md` + 
  13 个子 skill 安装到 `~/.codex/skills/`，让 Codex 用户也能用同一套                
  cheat-on-content 流程。                                                           
                                                            
  ## Why

  Claude Code 的 `/cheat-*` slash-command harness 在 Codex 没有等价物。Codex        
  用自然语言触发同一套子 skill，需要把 skill 文件铺到
  `~/.codex/skills/`，并且额外提供根路由 skill `cheat-on-content`（链到 repo 根，让 
  Codex 读到 root `SKILL.md` 做 trigger 路由）。            

  这条 PR 让一份代码同时服务两端，不改任何方法论 / state schema / Claude 行为。     
  
  ## Changes                                                                        
                                                            
  - `install.sh`
    - 新增 `--codex` / `--all` / `--claude` 选项，默认仍是 Claude Code
    - `CODEX_SKILLS` 比 `CLAUDE_SKILLS` 多一条 `cheat-on-content` 根 skill（指向    
  repo 根目录）                                                                     
    - 复用同一份 `detect_conflicts` / `install_skills` 函数，无重复逻辑             
    - 帮助信息 + 安装后提示同步更新                                                 
  - `uninstall.sh`                                          
    - 对称增加 `--codex` / `--all`，逻辑与 install 镜像
  - `README.md`                                                                     
    - "📦 安装"段加 Codex 安装命令 + 双端 / 冻结 / 卸载示例
  - `SKILL.md` / `CHANGELOG.md`                                                     
    - 标注 Codex 路由说明 + Unreleased 段记录改动                                   
                                                                                    
  ## Test                                                                           
                                                                                    
  - `bash install.sh --all` → 两端软链均创建，源路径正确                            
  - `bash install.sh --codex --copy` → 切换到 frozen copy 模式，根 skill 的 `.git`
  被剥除                                                                            
  - `bash uninstall.sh --codex` → 仅清理 Codex 端，Claude 端保留
  - 多轮 install/uninstall 反复验证幂等                                             
  - **不触碰**用户内容项目数据（`.cheat-state.json` / `predictions/` /              
  `rubric_notes.md` / `.cheat-hooks/`）                                             
                                                                                    
  ## Not in this PR                                                                 
                                                            
  - 没改 state schema / migration
  - 没改任何 skill 内容逻辑
  - v0.1.1 的 CHANGELOG bump 故意没带（版本号归 maintainer 决定）