### PR TITLE
docs: 观猹热榜第一 badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Your doubt — predicted too.
 </p>
 
 <p align="center">
+  <a href="https://watcha.cn/products/cheat-on-content">
+    <img src="docs/guancha-no1.svg" alt="观猹热榜第一" width="380">
+  </a>
+</p>
+
+<p align="center">
 <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-v0.1.0-orange" alt="Version"></a>
 &nbsp;
 <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -22,6 +22,12 @@
 </p>
 
 <p align="center">
+  <a href="https://watcha.cn/products/cheat-on-content">
+    <img src="guancha-no1.svg" alt="观猹热榜第一" width="380">
+  </a>
+</p>
+
+<p align="center">
 <a href="../CHANGELOG.md"><img src="https://img.shields.io/badge/version-v0.1.0-orange" alt="Version"></a>
 &nbsp;
 <a href="../LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>

--- a/docs/guancha-no1.svg
+++ b/docs/guancha-no1.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="430" height="120" viewBox="0 0 430 120" role="img" aria-label="观猹热榜 第一名">
+  <!-- golden rounded border card -->
+  <rect x="3" y="3" width="424" height="114" rx="14" ry="14"
+        fill="#ffffff" stroke="#b8860b" stroke-width="2.5"/>
+
+  <!-- ===== laurel wreath hugging the "1" ===== -->
+  <g fill="#b8860b" stroke="none">
+    <!-- stems -->
+    <g fill="none" stroke="#b8860b" stroke-width="1.6" stroke-linecap="round">
+      <path d="M50,80 Q34,57 55,29"/>
+      <path d="M94,80 Q110,57 89,29"/>
+    </g>
+    <!-- leaf shape: tip up at (0,-11), base at (0,0) -->
+    <!-- LEFT branch: bottom points out-down, curling up toward the top -->
+    <path d="M0,0 C3.5,-3 3.5,-8 0,-11 C-3.5,-8 -3.5,-3 0,0 Z" transform="translate(50,78) rotate(-122)"/>
+    <path d="M0,0 C3.5,-3 3.5,-8 0,-11 C-3.5,-8 -3.5,-3 0,0 Z" transform="translate(43,68) rotate(-100)"/>
+    <path d="M0,0 C3.5,-3 3.5,-8 0,-11 C-3.5,-8 -3.5,-3 0,0 Z" transform="translate(39,57) rotate(-76)"/>
+    <path d="M0,0 C3.5,-3 3.5,-8 0,-11 C-3.5,-8 -3.5,-3 0,0 Z" transform="translate(40,46) rotate(-54)"/>
+    <path d="M0,0 C3.5,-3 3.5,-8 0,-11 C-3.5,-8 -3.5,-3 0,0 Z" transform="translate(46,36) rotate(-34)"/>
+    <path d="M0,0 C3.5,-3 3.5,-8 0,-11 C-3.5,-8 -3.5,-3 0,0 Z" transform="translate(54,29) rotate(-16)"/>
+    <!-- RIGHT branch (mirror) -->
+    <path d="M0,0 C3.5,-3 3.5,-8 0,-11 C-3.5,-8 -3.5,-3 0,0 Z" transform="translate(94,78) rotate(122)"/>
+    <path d="M0,0 C3.5,-3 3.5,-8 0,-11 C-3.5,-8 -3.5,-3 0,0 Z" transform="translate(101,68) rotate(100)"/>
+    <path d="M0,0 C3.5,-3 3.5,-8 0,-11 C-3.5,-8 -3.5,-3 0,0 Z" transform="translate(105,57) rotate(76)"/>
+    <path d="M0,0 C3.5,-3 3.5,-8 0,-11 C-3.5,-8 -3.5,-3 0,0 Z" transform="translate(104,46) rotate(54)"/>
+    <path d="M0,0 C3.5,-3 3.5,-8 0,-11 C-3.5,-8 -3.5,-3 0,0 Z" transform="translate(98,36) rotate(34)"/>
+    <path d="M0,0 C3.5,-3 3.5,-8 0,-11 C-3.5,-8 -3.5,-3 0,0 Z" transform="translate(90,29) rotate(16)"/>
+  </g>
+
+  <!-- the "1" in the center of the wreath -->
+  <text x="72" y="76"
+        font-family="Georgia, 'Times New Roman', serif"
+        font-size="50" font-weight="700"
+        fill="#b8860b" text-anchor="middle">1</text>
+
+  <!-- ===== right-side text ===== -->
+  <text x="150" y="50"
+        font-family="-apple-system, 'PingFang SC', 'Microsoft YaHei', Helvetica, Arial, sans-serif"
+        font-size="18" fill="#b8860b">观猹热榜</text>
+  <text x="150" y="86"
+        font-family="-apple-system, 'PingFang SC', 'Microsoft YaHei', Helvetica, Arial, sans-serif"
+        font-size="30" font-weight="800" fill="#9a6f08">#1 热榜第一</text>
+</svg>


### PR DESCRIPTION
## 做了什么

给 README 加了一张「观猹热榜第一」金色月桂卡片（仿 ARIS 的 #1 Paper of the Day 版式）。

- 新增 \`docs/guancha-no1.svg\` —— 手画 SVG，金边圆角 + 月桂环抱「1」+ 两行字
- 卡片可点击，跳转到 https://watcha.cn/products/cheat-on-content
- 同时加入 \`README.md\` 与 \`docs/README_CN.md\`，位于语言切换栏下方

## 注意

观猹没有官方实时 badge，这是静态图——名次变动需手动改 SVG 里的 \`#1 热榜第一\`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)