### PR TITLE
fix: PR #50 review feedback - cold-start XHS routing & verify glob

### DIFF
--- a/skills/cheat-init/SKILL.md
+++ b/skills/cheat-init/SKILL.md
@@ -111,6 +111,15 @@ allowed-tools: Bash(*), Read, Write, Edit, Glob, WebFetch, Skill
 - 选 b/c/d/e/f/g → `true`，cheat-status 持续提示"你的形态可能需要 bump 调权重"
 - **不再有"严重不匹配"档**——所有形态都能跑工作流，只是有的 rubric 需要更激进的 bump
 
+**Q1.2: 短文平台**（仅 Q1=c 时问）
+
+> "你的短文主要在哪个平台发？
+> a) **小红书** — 推荐 xhs 专用 starter rubric
+> b) **微博 / X** — 即 thread
+> c) **其他 / 不确定"
+
+记录到 `short_text_platform`（`xhs` / `weibo-x` / `other`）。
+
 **Q1.5: 典型时长**（仅 Q1=a/d/f 时问）
 
 > "你的视频典型时长？
@@ -291,6 +300,7 @@ c) 不找 → state 标 `benchmark_status: none`，用通用 v0 起步
      "skill_version": "1.0.0",
      "rubric_version": "v0",
      "content_form": "<查 Q1 映射表，写 enum 字符串如 \"opinion-video\">",
+     "short_text_platform": "<Q1.2 派生: \"xhs\" / \"weibo-x\" / \"other\"; Q1≠c 时 null>",
      "typical_duration_seconds": <Q1.5 派生：30/90/240/450/900>,
      "target_publish_cadence_days": <Q1.6 派生：1/2/7/null>,
      "rubric_form_mismatch": <Q1=a→false；其他→true>,
@@ -335,7 +345,10 @@ c) 不找 → state 标 `benchmark_status: none`，用通用 v0 起步
     只能含通用语言（公式 / 维度定义 / bucket 边界），不能含真实视频名 / 实绩。
     每次 bump 升级时的 Memo（含证据数据 + 派生证据）写到 rubric-memo.md（下一步创建）。"
    ```
-   - 复制 `cheat-on-content/starter-rubrics/<form>-zero.md`（cold-start）或 `<form>.md`（已有数据时仍可参考）
+   - starter 选择规则：
+     - `content_form=opinion-video` → 复制 `starter-rubrics/opinion-video-zero.md`（cold-start）或参考 `opinion-video.md`
+     - `content_form=short-text` 且（`enabled_perf_adapters` 含 `xhs-explore` 或 `short_text_platform=xhs`）→ 复制 `starter-rubrics/xhs-post-zero.md`（cold-start）或参考 `xhs-post.md`
+     - 其他形态暂没有内置 starter → 询问用户是否先复制 `opinion-video-zero.md` 作为占位并在顶部标 `rubric_form_mismatch: true`，或让用户提供自定义 rubric
 
 2.5. **`rubric-memo.md`**（**新**——配合 cheat-score-blind 隔离协议）
    ```
@@ -515,6 +528,7 @@ cheat-learn-from 完成后回到 init 的 Phase 5。
 | `skill_version` | Phase 3 | 硬编码 "1.0.0" |
 | `rubric_version` | Phase 3 | "v0" |
 | `content_form` | Phase 3 | Q1 → 查映射表换 enum 值（**不是字母**） |
+| `short_text_platform` | Phase 3 | Q1.2 派生（Q1≠c 时 null） |
 | `typical_duration_seconds` | Phase 3 | Q1.5 派生 |
 | `target_publish_cadence_days` | Phase 3 | Q1.6 派生 |
 | `rubric_form_mismatch` | Phase 3 | Q1≠a → true |

--- a/tools/verify-package.sh
+++ b/tools/verify-package.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# One-shot package verification for cheat-on-content maintainers.
+# It is intentionally local-only: no network calls and no user project writes.
+
+set -uo pipefail
+
+ROOT="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+FAILURES=0
+
+fail() {
+  echo "? $*"
+  FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+  echo "? $*"
+}
+
+check_cmd() {
+  local label="$1"
+  shift
+  if "$@" >/tmp/cheat-verify.$$.out 2>/tmp/cheat-verify.$$.err; then
+    pass "$label"
+  else
+    fail "$label"
+    sed 's/^/    /' /tmp/cheat-verify.$$.err
+  fi
+  rm -f /tmp/cheat-verify.$$.out /tmp/cheat-verify.$$.err
+}
+
+echo "== cheat-on-content package verification =="
+echo "root: $ROOT"
+echo
+
+echo "== install list =="
+skills=()
+while IFS= read -r skill_name; do
+  skills+=("$skill_name")
+done < <(
+  awk '
+    /^SUB_SKILLS=\(/ { inside=1; next }
+    inside && /^\)/ { exit }
+    inside {
+      sub(/#.*/, "")
+      gsub(/[[:space:]]/, "")
+      if (length($0) > 0) print $0
+    }
+  ' "$ROOT/install.sh"
+)
+
+if [[ "${#skills[@]}" -eq 15 ]]; then
+  pass "install.sh declares 15 sub-skills"
+else
+  fail "install.sh declares ${#skills[@]} sub-skills, expected 15"
+fi
+
+for skill in "${skills[@]}"; do
+  if [[ -f "$ROOT/skills/$skill/SKILL.md" ]]; then
+    pass "skill exists: $skill"
+  else
+    fail "missing skill: skills/$skill/SKILL.md"
+  fi
+done
+
+echo
+echo "== package structure =="
+if find "$ROOT/skills" -type l | grep -q .; then
+  fail "skills/ contains symlinks:"
+  find "$ROOT/skills" -type l -print | sed 's/^/    /'
+else
+  pass "skills/ contains no symlinks"
+fi
+
+GIT_TOP=$(git -C "$ROOT" rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -n "$GIT_TOP" && "$ROOT" == "$GIT_TOP"* ]]; then
+  rel_root="${ROOT#"$GIT_TOP"/}"
+  if [[ "$rel_root" == "$ROOT" ]]; then
+    rel_root="."
+  fi
+  gitlinks=$(git -C "$GIT_TOP" ls-files --stage -- "$rel_root/skills" 2>/dev/null | awk '$1 == "160000" { print $4 }')
+  active_gitlinks=""
+  if [[ -n "$gitlinks" ]]; then
+    while IFS= read -r gitlink_path; do
+      [[ -z "$gitlink_path" ]] && continue
+      # During a conversion, the index may still remember a deleted gitlink until
+      # the maintainer stages the delete/add. Treat deleted gitlinks as pending
+      # conversion, but fail if the gitlink still exists in the working tree.
+      if [[ -e "$GIT_TOP/$gitlink_path" || -L "$GIT_TOP/$gitlink_path" ]]; then
+        active_gitlinks="${active_gitlinks}${gitlink_path}"$'\n'
+      fi
+    done <<< "$gitlinks"
+  fi
+  if [[ -n "$active_gitlinks" ]]; then
+    fail "skills/ contains active gitlinks:"
+    echo "$active_gitlinks" | sed '/^$/d; s/^/    /'
+  else
+    pass "skills/ contains no active gitlinks"
+  fi
+
+  if [[ "$ROOT" != "$GIT_TOP" ]]; then
+    flat_found=0
+    for dirname in adapters skills hooks migrations shared-references templates tools; do
+      if [[ -e "$GIT_TOP/$dirname" ]]; then
+        echo "    $GIT_TOP/$dirname"
+        flat_found=1
+      fi
+    done
+    if [[ "$flat_found" -eq 0 ]]; then
+      pass "no upstream-flattened package dirs at repository root"
+    else
+      fail "found package dirs at repository root; keep them under cheat-on-content/"
+    fi
+  fi
+fi
+
+echo
+echo "== shell syntax =="
+while IFS= read -r sh_file; do
+  check_cmd "bash -n ${sh_file#$ROOT/}" bash -n "$sh_file"
+done < <(
+  find "$ROOT" \
+    \( -path "$ROOT/install.sh" -o -path "$ROOT/uninstall.sh" -o -path "$ROOT/hooks/*.sh" -o -path "$ROOT/adapters/perf-data/*/run.sh" -o -path "$ROOT/adapters/script-extraction/*/run.sh" -o -path "$ROOT/tools/*.sh" \) \
+    -type f | sort
+)
+
+echo
+echo "== python syntax =="
+while IFS= read -r py_file; do
+  check_cmd "py_compile ${py_file#$ROOT/}" python3 -m py_compile "$py_file"
+done < <(
+  find "$ROOT/tools" "$ROOT/adapters/perf-data" "$ROOT/skills" -name '*.py' -type f | sort
+)
+
+echo
+echo "== focused tests =="
+if [[ -x "$ROOT/tools/diff_pct_test.sh" || -f "$ROOT/tools/diff_pct_test.sh" ]]; then
+  check_cmd "diff_pct_test.sh" bash "$ROOT/tools/diff_pct_test.sh"
+else
+  fail "missing tools/diff_pct_test.sh"
+fi
+
+echo
+echo "== xhs writing rules =="
+python3 - "$ROOT" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+files = {
+    "starter-rubrics/xhs-post.md": root / "starter-rubrics" / "xhs-post.md",
+    "starter-rubrics/xhs-post-zero.md": root / "starter-rubrics" / "xhs-post-zero.md",
+    "skills/cheat-seed/SKILL.md": root / "skills" / "cheat-seed" / "SKILL.md",
+    "templates/xhs-post.template.md": root / "templates" / "xhs-post.template.md",
+}
+combined = "\n".join(path.read_text() for path in files.values())
+required = [
+    "?20",
+    "600-900",
+    "? 2 ?",
+    "???",
+    "???",
+    "???",
+    "???",
+    "???",
+    "?? 2-4 ?",
+]
+missing = [item for item in required if item not in combined]
+missing_files = [name for name, path in files.items() if not path.exists()]
+if missing_files or missing:
+    if missing_files:
+        print("missing files:", ", ".join(missing_files), file=sys.stderr)
+    if missing:
+        print("missing rules:", ", ".join(missing), file=sys.stderr)
+    raise SystemExit(1)
+PY
+if [[ "$?" -eq 0 ]]; then
+  pass "xhs title/body/layout rules present"
+else
+  fail "xhs title/body/layout rules missing"
+fi
+
+echo
+echo "== install help =="
+if bash "$ROOT/install.sh" --help | grep -q "15 sub-skills"; then
+  pass "install.sh --help reports 15 sub-skills"
+else
+  fail "install.sh --help does not report 15 sub-skills"
+fi
+
+echo
+if [[ "$FAILURES" -eq 0 ]]; then
+  echo "? verify-package passed"
+  exit 0
+else
+  echo "? verify-package failed: $FAILURES issue(s)"
+  exit 1
+fi


### PR DESCRIPTION
Addresses both review issues from @Jooonnn on PR #50:

**Fix 1: Cold-start XHS routing bug**
Added Q1.2 follow-up question for short-text users to specify their target platform (xiaohongshu/weibo-x/other). Starter selection now checks both \enabled_perf_adapters\ (for existing users) and \short_text_platform\ (for cold-start users).

**Fix 2: Verify script glob coverage**
Shell syntax check find glob now includes \dapters/script-extraction/*/run.sh\ to cover the whisper adapter.

See individual commits for full changes.