### PR TITLE
fix: update douyin work detail metrics capture

### DIFF
--- a/adapters/perf-data/douyin-session/README.md
+++ b/adapters/perf-data/douyin-session/README.md
@@ -14,7 +14,7 @@ douyin-session 用 **Playwright + 持久化 Chromium context** 模拟真实浏�
 - 你首次扫码登录抖音创作者中心，cookie 存在**你的内容项目根目录** `.auth/`
 - 之后每次抓取直接复用 cookie，不用重新登录
 - 拦截抖音前端的 XHR responses 直接抓数据接口的 JSON（不解析 HTML）
-- 抓 3 类数据：视频列表 / 详细数据（完播 / 转粉率）/ 评论
+- 抓 3 类数据：视频列表 / 作品详情数据（总览 / 流量分析 / 观众分析 / 评论热词等）/ 评论
 
 输出写到**你的内容项目** `videos/<...>/report.md`（`cheat-retro` 读这个文件 → 摘要写到 prediction 复盘段）。
 调试产物（URL dump / 截图）写到 `.cheat-cache/douyin-session-debug/`，避免散落在 skill 源码目录。
@@ -74,7 +74,7 @@ cheat-publish 会在登记发布时把 aweme_id 存到 prediction header（如�
 由 `renderer.py` 生成。包含：
 - 视频元信息（标题、发布时间、时长）
 - 数据快照（播放、点赞、评论、转发、收藏 + 派生比率：赞播比 / 评播比 / 分播比）
-- 完播率 / 3s 留存（如能抓到）
+- 创作者中心详细指标：完播率 / 5s 完播率 / 2s 划走率 / 文案展开率 / 平均浏览图片数 / 粉丝播放占比（如能抓到）
 - Top 20 评论（按赞数排序，含评论文本 + 赞数）
 - 评论关键词聚类（renderer 自动做，可选）
 
@@ -84,6 +84,7 @@ cheat-publish 会在登记发布时把 aweme_id 存到 prediction header（如�
 |---|---|---|
 | `ensure_login` 超时 | cookie 过期或抖音强制 reauth | 重新跑 `python crawler.py login` |
 | `_parse_video_list` 返回空 | 抖音改了接口字段——结构性变化 | 看 `.debug/creator_urls.txt` 抓到的 URL，更新 crawler.py 的字段兜底 |
+| 详细数据接口没拦到 | 作品详情页路由或接口改版 | 先确认作品详情页是否仍是 `/creator-micro/work-management/work-detail/<aweme_id>?enter_from=content`，再看 `.debug/detail_urls.txt` 更新 `fetch_video_detail` 的匹配规则 |
 | `_parse_video_list` 视频列表不全 | 翻页没抓到——网络慢或反爬触发 | 调高 `crawler.py` 里的 `await asyncio.sleep(...)` 时长 |
 | Chromium 崩溃 / 卡死 | 通常是机器内存不足 | 关闭其他 Chromium 进程；`playwright install chromium --force` 重装 |
 | 评论抓取慢（>5min） | 评论页 XHR 多次滚动触发——慢网络 | 调小 `fetch_comments_creator` 的 `max_pages`，或换更稳的网络 |

--- a/adapters/perf-data/douyin-session/crawler.py
+++ b/adapters/perf-data/douyin-session/crawler.py
@@ -15,6 +15,33 @@ from paths import auth_dir, debug_dir
 
 CREATOR_HOME = "https://creator.douyin.com/creator-micro/home"
 CREATOR_CONTENT = "https://creator.douyin.com/creator-micro/content/manage"
+CREATOR_WORK_DETAIL = "https://creator.douyin.com/creator-micro/work-management/work-detail"
+DETAIL_RESPONSE_KEYWORDS = (
+    "data_center",
+    "data_external",
+    "aweme_statistic",
+    "item_detail",
+    "statistics",
+    "work_detail",
+    "work_management",
+    "creator/item/mget",
+    "diagnose/item_compare",
+    "item_analysis",
+    "data/item/",
+    "comment",
+    "keyword",
+    "hot_word",
+    "hotword",
+    "flow",
+    "traffic",
+    "audience",
+    "overview",
+)
+DETAIL_RESPONSE_EXCLUDE_KEYWORDS = (
+    "prefetch",
+    "item/auth",
+    "author/upgrade",
+)
 
 
 class Session:
@@ -173,10 +200,7 @@ async def fetch_video_detail(sess: Session, aweme_id: str) -> dict:
 
     async def on_response(resp: Response) -> None:
         all_urls.append(resp.url)
-        if any(k in resp.url for k in (
-            "data_center", "data_external", "aweme_statistic",
-            "item_detail", "statistics", "/data/",
-        )):
+        if _looks_like_detail_response(resp.url, aweme_id):
             try:
                 data = await resp.json()
                 captured.append({"url": resp.url, "data": data})
@@ -185,9 +209,15 @@ async def fetch_video_detail(sess: Session, aweme_id: str) -> dict:
 
     page.on("response", on_response)
     try:
-        url = f"https://creator.douyin.com/creator-micro/data/following/media?item_id={aweme_id}"
+        url = f"{CREATOR_WORK_DETAIL}/{aweme_id}?enter_from=content"
         await page.goto(url, wait_until="domcontentloaded", timeout=60000)
-        await asyncio.sleep(6)
+        await asyncio.sleep(8)
+        for tab in ("总览", "流量分析", "观众分析", "评论热词"):
+            try:
+                await page.get_by_text(tab, exact=True).first.click(timeout=3000)
+                await asyncio.sleep(3)
+            except Exception:
+                pass
         if not captured:
             debug_path = debug_dir()
             debug_path.mkdir(parents=True, exist_ok=True)
@@ -196,6 +226,25 @@ async def fetch_video_detail(sess: Session, aweme_id: str) -> dict:
         return {"captured": captured}
     finally:
         await page.close()
+
+
+def _looks_like_detail_response(url: str, aweme_id: str) -> bool:
+    if "creator.douyin.com" not in url and "creator.amemv.com" not in url:
+        return False
+    if any(k in url for k in DETAIL_RESPONSE_EXCLUDE_KEYWORDS):
+        return False
+    if aweme_id in url and any(k in url for k in (
+        "creator/item/mget",
+        "item_analysis",
+        "data/item/",
+        "comment",
+        "keyword",
+        "hot_word",
+        "hotword",
+        "diagnose/item_compare",
+    )):
+        return True
+    return any(k in url for k in DETAIL_RESPONSE_KEYWORDS)
 
 
 async def fetch_comments_creator(sess: Session, aweme_id: str, max_pages: int = 60) -> list[dict]:

--- a/adapters/perf-data/douyin-session/renderer.py
+++ b/adapters/perf-data/douyin-session/renderer.py
@@ -14,9 +14,32 @@ def _fmt_time(ts: int) -> str:
 def _fmt_num(n: int | None) -> str:
     if n is None:
         return "-"
+    if isinstance(n, str):
+        try:
+            n = int(float(n))
+        except ValueError:
+            return n
     if n >= 10000:
         return f"{n/10000:.1f}w"
     return str(n)
+
+
+def _fmt_float(v, digits: int = 2) -> str:
+    if v is None:
+        return "-"
+    try:
+        return f"{float(v):.{digits}f}"
+    except (TypeError, ValueError):
+        return str(v)
+
+
+def _fmt_percent(v) -> str:
+    if v is None:
+        return "-"
+    try:
+        return f"{float(v) * 100:.2f}%"
+    except (TypeError, ValueError):
+        return str(v)
 
 
 def _fmt_duration(ms: int) -> str:
@@ -24,6 +47,37 @@ def _fmt_duration(ms: int) -> str:
         return "-"
     s = ms // 1000
     return f"{s//60}:{s%60:02d}" if s >= 60 else f"{s}s"
+
+
+def _first_metrics(detail_captured: list[dict] | None) -> dict:
+    if not detail_captured:
+        return {}
+    for item in detail_captured:
+        data = item.get("data")
+        if not isinstance(data, dict):
+            continue
+        items = data.get("items")
+        if isinstance(items, list) and items and isinstance(items[0], dict):
+            metrics = items[0].get("metrics")
+            if isinstance(metrics, dict):
+                return metrics
+        item_data = data.get("item")
+        if isinstance(item_data, dict) and isinstance(item_data.get("metrics"), dict):
+            return item_data["metrics"]
+    return {}
+
+
+def _detail_sample_items(detail_captured: list[dict]) -> list[dict]:
+    samples = detail_captured[:3]
+    sample_urls = {item.get("url") for item in samples}
+    for item in detail_captured[3:]:
+        url = item.get("url") or ""
+        if item.get("url") in sample_urls:
+            continue
+        if any(k in url for k in ("comment", "keyword", "hot_word", "hotword")):
+            samples.append(item)
+            break
+    return samples
 
 
 def render_report(
@@ -54,12 +108,40 @@ def render_report(
     lines.append(f"- 分享：{_fmt_num(video.get('share_count'))}")
     lines.append("")
 
-    if detail_captured:
+    metrics = _first_metrics(detail_captured)
+    if metrics:
         lines.append("### 详细指标（来自创作者中心）")
+        lines.append("")
+        detail_rows = [
+            ("播放", _fmt_num(metrics.get("view_count"))),
+            ("完播率", _fmt_percent(metrics.get("completion_rate"))),
+            ("5s 完播率", _fmt_percent(metrics.get("completion_rate_5s"))),
+            ("2s 划走率", _fmt_percent(metrics.get("bounce_rate_2s"))),
+            (
+                "平均观看时长",
+                f"{_fmt_float(metrics.get('avg_view_second'))}s"
+                if metrics.get("avg_view_second") is not None
+                else "-",
+            ),
+            ("文案展开率", _fmt_percent(metrics.get("description_spread_rate"))),
+            ("文案读完率", _fmt_percent(metrics.get("description_completion_rate"))),
+            ("平均浏览图片数", _fmt_float(metrics.get("image_avg_view_count"))),
+            ("粉丝播放占比", _fmt_percent(metrics.get("fan_view_proportion"))),
+            ("主页访问", _fmt_num(metrics.get("homepage_visit_count"))),
+            ("涨粉", _fmt_num(metrics.get("subscribe_count"))),
+            ("脱粉", _fmt_num(metrics.get("unsubscribe_count"))),
+        ]
+        for label, value in detail_rows:
+            if value != "-":
+                lines.append(f"- {label}：{value}")
+        lines.append("")
+
+    if detail_captured:
+        lines.append("### 详细接口原始样例")
         lines.append("")
         lines.append("```json")
         import json
-        for item in detail_captured[:3]:
+        for item in _detail_sample_items(detail_captured):
             full = json.dumps(item["data"], ensure_ascii=False, indent=2)
             truncated = full[:2000]
             if len(full) > 2000:


### PR DESCRIPTION
## Summary
- Update the Douyin creator detail page route from the old `/data/following/media?item_id=...` page to the current `/work-management/work-detail/<aweme_id>?enter_from=content` page.
- Capture current work-detail metric endpoints such as `creator/item/mget`, `item_analysis`, `item/play/source`, realtime `data_center`, and comment/keyword responses.
- Click creator-center detail tabs for overview, traffic analysis, audience analysis, and comment hot words so the report can retain those responses when available.
- Render key creator-center metrics in reports, including completion rate, 2s bounce rate, description spread rate, average image views, fan view proportion, follows, and unfollows.

## Root cause
Douyin Creator Center moved detailed work analytics behind the work-management detail page. The adapter could still read the basic work list, but the old detail route no longer triggered the analytics XHRs, causing `详细数据接口没拦到`.

## Verification
- `python -m py_compile adapters/perf-data/douyin-session/crawler.py adapters/perf-data/douyin-session/renderer.py`
- Verified locally against a published image-text work: detail capture returned relevant work-detail responses, including a keyword/comment response, and rendered creator-center metrics including 2s bounce rate, description spread rate, and average image views.