### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #68)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cheat-on-content
 description: 给所有想把"感觉"变成可校准预测的内容创作者。**方法论通用**——打分 → 盲预测 → T+3d 复盘 → 进化 rubric 的循环适用任何能被量化（播放 / 阅读 / 收听 / 点击）的内容。**rubric 是循环的内容，不是循环本身**——当前内置一份观点视频 rubric（参考博主 25+ 视频拟合），其他形态可借这套起步并 bump 调权重。**强烈建议导入对标账号**作为初始信号源（/cheat-learn-from）。触发词："初始化"/"打分这篇"/"启动预测"/"已发布"/"复盘"/"升级 rubric"/"推荐选题"/"抓热点"/"状态"/"找对标"/"learn from"。**首次使用必须先跑 /cheat-init。**
-argument-hint: [draft-path] [— mode: cold-start|calibration]
+argument-hint: "[draft-path] [— mode: cold-start|calibration]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Skill, mcp__llm-chat__chat
 ---
 

--- a/skills/cheat-init/SKILL.md
+++ b/skills/cheat-init/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cheat-init
 description: cheat-on-content 的首次 onboarding 与脚手架创建器。统一流程——所有用户都走相同 5 阶段闭环，唯一区别是"发过视频的人"会在 init 时多一步：抓取已有视频建立历史 context（用于后续 cheat-seed 给更贴合的选题、更准的 baseline）。触发词："初始化"/"init"/"首次使用"/"我是新用户"/"setup cheat-on-content"。**必须在用户第一次会话执行；其他子 skill 在 .cheat-state.json 不存在时自动路由到此。**
-argument-hint: [— form: opinion-video|long-essay|short-text|podcast]
+argument-hint: "[— form: opinion-video|long-essay|short-text|podcast]"
 allowed-tools: Bash(*), Read, Write, Edit, Glob, WebFetch, Skill
 ---
 

--- a/skills/cheat-migrate/SKILL.md
+++ b/skills/cheat-migrate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cheat-migrate
 description: 把老用户的 .cheat-state.json 升级到当前 schema_version。读 migrations/registry.md 算迁移链，按顺序应用每一步迁移文件。幂等：跑两次结果一样。失败停在中间版本不前进。触发词："迁移"/"升级 state"/"migrate"/"我的 state 是老版本"/"schema 版本不对"。
-argument-hint: [— from: <version>] [— to: <version>] [— dry-run]
+argument-hint: "[— from: <version>] [— to: <version>] [— dry-run]"
 allowed-tools: Bash(*), Read, Write, Edit, Skill
 ---
 

--- a/skills/cheat-persona/SKILL.md
+++ b/skills/cheat-persona/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cheat-persona
 description: 从复盘评论数据派生 / 刷新账号的受众画像，写入 audience.md。这是和 rubric 平行的第二个派生物——rubric 答"怎么打分"，persona 答"谁在看"。cheat-seed 选题 / 写稿时读它。**audience.md 含实绩信号，cheat-score-blind 硬禁读**。触发词："构造受众画像"/"更新 persona"/"我的观众是谁"/"build persona"/"刷新受众画像"/"看看我的受众画像"。
-argument-hint: [— seed-from-benchmark] [— rebuild]
+argument-hint: "[— seed-from-benchmark] [— rebuild]"
 allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep
 ---
 

--- a/skills/cheat-recommend/SKILL.md
+++ b/skills/cheat-recommend/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cheat-recommend
 description: 从 candidates.md 里按当前 rubric 排序推荐 top N 选题，每条带 composite + 一句 rationale + 锚点对比。**candidates 不存在时给引导而非报错**。触发词："推荐选题"/"next topic"/"下一篇做什么"/"recommend topics"/"挑一个选题"。
-argument-hint: [— top: N] [— filter: tier1|all|safe|risky]
+argument-hint: "[— top: N] [— filter: tier1|all|safe|risky]"
 allowed-tools: Read, Glob, Grep
 ---
 

--- a/skills/cheat-seed/SKILL.md
+++ b/skills/cheat-seed/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cheat-seed
 description: 跟用户对话讨论选题——**默认一次一个**，用户主动给主题或经历，AI 围绕用户的输入深挖、提炼角度、写一份 draft。不是 AI 拿三个开放问题追用户，也不是一次给 5 个候选。触发词："找选题"/"我想做一条 X"/"最近有个想法"/"seed"/"启动种子"。可选 batch 模式：`/cheat-seed --batch 5` 走旧的 brainstorm 5 候选 + 写 5 draft 流程。
-argument-hint: [— batch: N] [— sources: <comma-separated>]
+argument-hint: "[— batch: N] [— sources: <comma-separated>]"
 allowed-tools: Bash(*), Read, Write, Edit, Glob, WebFetch, Skill
 ---
 

--- a/skills/cheat-trends/SKILL.md
+++ b/skills/cheat-trends/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cheat-trends
 description: 从配置的热点源（HN / Reddit / YouTube trending / B 站热门 / 等）抓今天的热门话题，去重 + 粗打分 + 写入 candidates.md。**绝大部分人没有候选池——这是让"我没素材"问题在 onboarding 第二步就消失的钥匙**。触发词："抓热点"/"fetch trends"/"今天有什么可做的"/"trending now"/"找选题"。
-argument-hint: [— sources: <comma-separated>] [— max-per: 20]
+argument-hint: "[— sources: <comma-separated>] [— max-per: 20]"
 allowed-tools: Bash(*), Read, Write, Edit, Glob, WebFetch, Skill
 ---
 


### PR DESCRIPTION
Closes #68.

## Summary

Purely mechanical single-character transform to 7 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (7)

- `skills/cheat-trends/SKILL.md`
- `skills/cheat-migrate/SKILL.md`
- `skills/cheat-persona/SKILL.md`
- `skills/cheat-recommend/SKILL.md`
- `skills/cheat-seed/SKILL.md`
- `skills/cheat-init/SKILL.md`
- `SKILL.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- Regression sweep: no unquoted-bracket `argument-hint:` lines remain in these files
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
